### PR TITLE
Fix perfdata creation

### DIFF
--- a/checks/lmsensors
+++ b/checks/lmsensors
@@ -105,7 +105,7 @@ def check_min_max(item, params, info):
 		return (3, "UNKNOWN - sensor status not found in agent output")
 	value = float(values[1])
 	stype = values[2]
-	perfdata = [ ( item, value, "", my_save_float(smax) ) ]
+	perfdata = [ ( 'value', value, "", my_save_float(smax) ) ]
 	if smax != None and value > float(smax):
 		return (2, "CRITICAL - Sensor value %s %s, which is bigger than %s" % (value, stype, smax), perfdata)
 	elif smin != None and value < float(smin):
@@ -128,7 +128,7 @@ def check_high_crit(item, params, info):
 		return (3, "UNKNOWN - sensor status not found in agent output")
 	value = float(values[1])
 	stype = values[2]
-	perfdata = [ ( item, value, "", my_save_float(high) ) ]
+	perfdata = [ ( 'value', value, "", my_save_float(high) ) ]
 
 	if crit != None and value > float(crit):
 		return (2, "CRITICAL - Sensor value %s %s, which is bigger than %s" % (value, stype, crit), perfdata)


### PR DESCRIPTION
This fixes "Failed to parse perfdata […]" in ~/var/log/web.log

```
Traceback (most recent call last):
  File "/omd/sites/[…]/lib/python/cmk/gui/plugins/metrics/utils.py", line 239, in parse_perf_data
    varname, value_text, value_parts = parse_perf_values(part)
  File "/omd/sites/[…]/lib/python/cmk/gui/plugins/metrics/utils.py", line 180, in parse_perf_values
    varname, values = data_str.split("=", 1)
ValueError: need more than 1 value to unpack
```

This fixes https://github.com/modusoft/lm-sensors/issues/2